### PR TITLE
Lots of things

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,21 @@ Welcome to the Bedlam Theatre Scavenger Hunt scoring website.
 2) You can view test coverage by opening `coverage/index.html` using a browser of your choice.
 
 # Deployment
-TBD
+Currently it is deployed on the EUSA VM using Docker, with the nginx file used to route incoming traffic for scavhunt.bedlamtheatre.co.uk to port 2024, which is the port that Docker has exposed the server on.
+
+## Upgrading
+If you want to upgrade, that means you have to `sudo docker compose down` the current image to stop it, and follow the deploy steps.
+
+## Deploying
+The deploy steps are:
+1) Clone this repository
+2) Navigate into the repository
+3) Add a `.env` file with the contents below.
+4) Run `sudo docker compose -f docker-compose.yml up -d` (this will create new containers and start them detached so it will still run when you log out. You might need to add the `--build rails` or `--force-recreate` options when upgrading)
+5) That's it! You can check if it is running using `sudo docker ps`
+
+## Environment Variables
+Ensure that the environment variables are specified in Portainer or in an `.env` file as follows:
+- `RAILS_MASTER_KEY`: the master key.
+- `DATABASE_NAME`: `scav_hunt_production`
+- `DATABASE_PASSWORD`: Anything you want

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   rescue_from CanCan::AccessDenied do |exception|
-    # TODO: Render proper access denied page. See Black Lightning
+    # FIXME: Render proper access denied page. See Black Lightning
     redirect_to root_path, alert: "I'm sorry, I can't let you do that"
   end
 end

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -105,11 +105,12 @@ class ChallengesController < ApplicationController
   end
 
   def export
-    # TODO: This should also export the points for each team for each challenge.
-    @challenges = Challenge.order(:number)
+    @challenges = Challenge.includes(results: :user).order(:number)
+    @teams = User.teams_by_name
 
     response.headers["Content-Type"] = "text/csv"
     response.headers["Content-Disposition"] = "attachment; filename=challenges-#{Date.today}.csv"
+
     render template: "challenges/export", formats: :csv
   end
 

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -105,6 +105,7 @@ class ChallengesController < ApplicationController
   end
 
   def export
+    # TODO: This should also export the points for each team for each challenge.
     @challenges = Challenge.order(:number)
 
     response.headers["Content-Type"] = "text/csv"

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -10,7 +10,7 @@ class ChallengesController < ApplicationController
 
     # Include the results for this user if the user is a team.
     if current_user.team?
-      @results = Result.where(user: current_user).index_by(&:challenge_id)
+      @results = Result.includes(:challenge).where(user: current_user).index_by(&:challenge_id)
     end
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,13 +1,23 @@
 class HomeController < ApplicationController
   def index
     @title = "Scoreboard"
-    @teams = User.teams_ranked
+    @teams = Rails.cache.fetch("teams_ranked", expires_in: 5.minutes) do
+      User.teams_ranked
+    end
 
-    # TODO: Cache until the scores change -> On result update.
+    @end_time = DateTime.new(2024, 9, 27, 14, 0, 0, "+01:00")
 
     respond_to do |format|
       format.html
-      format.json { render json: @teams.map { |team| team.scoreboard_data(current_ability) } }
+      format.json { render json: teams_json }
+    end
+  end
+
+  private
+
+  def teams_json
+    Rails.cache.fetch("teams_json", expires_in: 1.minute) do
+      @teams.map { |team| team.scoreboard_data(current_ability) }
     end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,8 @@ class HomeController < ApplicationController
     @title = "Scoreboard"
     @teams = User.teams_ranked
 
+    # TODO: Cache until the scores change -> On result update.
+
     respond_to do |format|
       format.html
       format.json { render json: @teams.map { |team| team.scoreboard_data(current_ability) } }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,7 @@ class HomeController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json { render json: @teams.map { |team| { id: team.id, name: team.name, score: team.results.sum(&:total_points) } } }
+      format.json { render json: @teams.map { |team| team.scoreboard_data(current_ability) } }
     end
   end
 end

--- a/app/controllers/scoring_controller.rb
+++ b/app/controllers/scoring_controller.rb
@@ -24,7 +24,7 @@ class ScoringController < ApplicationController
     @result.bonus_points = params[:bonus_points]
 
     if @result.save
-      render json: { status: "success", result: @result }
+      render json: { status: "success", result: @result.as_json }
     else
       render json: { status: "error", errors: @result.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/scoring_controller.rb
+++ b/app/controllers/scoring_controller.rb
@@ -14,7 +14,6 @@ class ScoringController < ApplicationController
   def score
     @team = User.find(params[:id])
 
-    # TODO: Test this case.
     if !@team.team?
       redirect_to scoring_path, notice: "Only teams can be scored."
     end

--- a/app/controllers/scoring_controller.rb
+++ b/app/controllers/scoring_controller.rb
@@ -21,7 +21,7 @@ class ScoringController < ApplicationController
     @title = "Scoring #{@team.name}"
 
     @challenges = Challenge.by_number
-    @results = Result.where(user: @team).index_by(&:challenge_id)
+    @results = Result.includes(:challenge).where(user: @team).index_by(&:challenge_id)
   end
 
   def update

--- a/app/controllers/scoring_controller.rb
+++ b/app/controllers/scoring_controller.rb
@@ -2,13 +2,7 @@ class ScoringController < ApplicationController
   authorize_resource class: :scoring
 
   def index
-    # TODO: Add extra features to the scorer side of the scoreboard, such as how many tasks each team has completed etc.
-    @title = "Scoreboard"
-    @teams = User.teams_ranked
-
-    respond_to do |format|
-      format.html { render "home/index" }
-    end
+    redirect_to root_path
   end
 
   def score

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,9 +19,10 @@ class UsersController < ApplicationController
   end
 
   def create
-    # TODO: Issues with creating a user
-    #
-    if @user.save(user_params)
+    # TODO: Issues with creating a user. Gives error: " You are already signed in. "
+    @user = User.new(user_params)
+
+    if @user.save
       redirect_to @user, notice: "User was successfully created."
     else
       set_new_user_title

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,6 @@ class UsersController < ApplicationController
   end
 
   def create
-    # TODO: Issues with creating a user. Gives error: " You are already signed in. "
     @user = User.new(user_params)
 
     if @user.save

--- a/app/javascript/controllers/scoreboard_controller.js
+++ b/app/javascript/controllers/scoreboard_controller.js
@@ -85,6 +85,12 @@ export default class extends Controller {
       row.insertCell().textContent = index + 1
       row.insertCell().textContent = team.name
       row.insertCell().textContent = team.score
+
+      if (team.completed) {
+        row.insertCell().textContent = team.completed
+        row.insertCell().textContent= team.partially_completed
+        row.insertCell().textContent = team.not_attempted
+      }
     })
   }
 }

--- a/app/javascript/controllers/scoreboard_controller.js
+++ b/app/javascript/controllers/scoreboard_controller.js
@@ -32,9 +32,6 @@ export default class extends Controller {
   }
 
   startCountdownTimer() {
-    // TODO: Set the end time value.
-    this.endTimeValue = new Date("2024-09-28T15:00:00").toISOString()
-    
     this.countdownTimerId = setInterval(() => {
       this.updateCountdownTimer()
     }, 1000)
@@ -78,18 +75,19 @@ export default class extends Controller {
 
   updateTable(teams) {
     const tableBody = this.tableBodyTarget
-    tableBody.innerHTML = ''
-
+    
     teams.forEach((team, index) => {
-      const row = tableBody.insertRow()
-      row.insertCell().textContent = index + 1
-      row.insertCell().textContent = team.name
-      row.insertCell().textContent = team.score
+      const row = tableBody.querySelector(`tr[data-team-id="${team.id}"]`)
 
-      if (team.completed) {
-        row.insertCell().textContent = team.completed
-        row.insertCell().textContent= team.partially_completed
-        row.insertCell().textContent = team.not_attempted
+      // Find the existing row, and update it. 
+      if (row) {
+        row.querySelector('[data-rank]').textContent = index + 1
+        row.querySelector('[data-score]').textContent = team.score
+        if (team.completed) {
+          row.querySelector('[data-completed]').textContent = team.completed
+          row.querySelector('[data-partially-completed]').textContent = team.partially_completed
+          row.querySelector('[data-not-attempted]').textContent = team.not_attempted
+        }
       }
     })
   }

--- a/app/javascript/controllers/scoreboard_controller.js
+++ b/app/javascript/controllers/scoreboard_controller.js
@@ -56,7 +56,7 @@ export default class extends Controller {
       const minutes = Math.floor((timeLeft % (1000 * 60 * 60)) / (1000 * 60))
       const seconds = Math.floor((timeLeft % (1000 * 60)) / 1000)
 
-      this.timerTarget.textContent = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+      this.timerTarget.textContent = `${hours.toString()} hours, ${minutes.toString()} minutes, ${seconds.toString()} seconds`
     }
   }
 

--- a/app/javascript/controllers/scoring_controller.js
+++ b/app/javascript/controllers/scoring_controller.js
@@ -1,18 +1,56 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = ["regularPoints", "bonusPoints", "status", "totalPoints"]
+
+  connect() {
+    this.previousValues = {}
+  }
+
   updateScore(event) {
     const input = event.target
     const challengeId = input.dataset.challengeId
     const userId = input.dataset.userId
-    const regularPoints = this.regularPointsTargets.find(target => 
-      target.dataset.challengeId === challengeId && target.dataset.userId === userId
-    ).value
-    const bonusPoints = this.bonusPointsTargets.find(target => 
-      target.dataset.challengeId === challengeId && target.dataset.userId === userId
-    ).value
+    const regularPoints = this.getRegularPoints(challengeId, userId)
+    const bonusPoints = this.getBonusPoints(challengeId, userId)
 
+    this.savePreviousValue(input)
     this.sendUpdateRequest(challengeId, userId, regularPoints, bonusPoints)
+  }
+
+  undoRegularPoints(event) {
+    const button = event.target
+    const challengeId = button.dataset.challengeId
+    const userId = button.dataset.userId
+    const input = this.getRegularPointsInput(challengeId, userId)
+    
+    if (this.previousValues[input.id]) {
+      input.value = this.previousValues[input.id]
+      this.updateScore({ target: input })
+    }
+  }
+
+  undoBonusPoints(event) {
+    const button = event.target
+    const challengeId = button.dataset.challengeId
+    const userId = button.dataset.userId
+    const input = this.getBonusPointsInput(challengeId, userId)
+    
+    if (this.previousValues[input.id]) {
+      input.value = this.previousValues[input.id]
+      this.updateScore({ target: input })
+    }
+  }
+
+  awardFullPoints(event) {
+    const button = event.target
+    const challengeId = button.dataset.challengeId
+    const userId = button.dataset.userId
+    const regularPointsInput = this.getRegularPointsInput(challengeId, userId)
+    const pointsToWin = regularPointsInput.dataset.pointsToWin
+
+    regularPointsInput.value = pointsToWin
+    this.updateScore({ target: regularPointsInput })
   }
 
   sendUpdateRequest(challengeId, userId, regularPoints, bonusPoints) {
@@ -27,11 +65,74 @@ export default class extends Controller {
     .then(response => response.json())
     .then(data => {
       if (data.status === 'success') {
-        console.log('Score updated successfully')
+        this.updateUI(challengeId, userId, data.result)
       } else {
         console.error('Error updating score:', data.errors)
       }
     })
     .catch(error => console.error('Error:', error))
+  }
+
+  updateUI(challengeId, userId, result) {
+    const regularPointsInput = this.getRegularPointsInput(challengeId, userId)
+    const bonusPointsInput = this.getBonusPointsInput(challengeId, userId)
+    const statusElement = this.getStatusElement(challengeId)
+
+    regularPointsInput.value = result.regular_points
+    bonusPointsInput.value = result.bonus_points
+    statusElement.textContent = result.status
+
+    // TODO: Either flash the whole row, or just the element that was updated, but not both.
+    this.flashElement(regularPointsInput)
+    this.flashElement(bonusPointsInput)
+    this.updateTotalPoints()
+  }
+
+  updateTotalPoints() {
+    const totalPoints = Array.from(this.regularPointsTargets).reduce((sum, input) => {
+      return sum + parseInt(input.value || 0)
+    }, 0) + Array.from(this.bonusPointsTargets).reduce((sum, input) => {
+      return sum + parseInt(input.value || 0)
+    }, 0)
+
+    this.totalPointsTarget.textContent = totalPoints
+  }
+
+
+  flashElement(element) {
+    element.classList.add('flash-green')
+    setTimeout(() => {
+      element.classList.remove('flash-green')
+    }, 1000)
+  }
+
+  savePreviousValue(input) {
+    if (!this.previousValues[input.id]) {
+      this.previousValues[input.id] = input.value
+    }
+  }
+
+  getRegularPoints(challengeId, userId) {
+    return this.getRegularPointsInput(challengeId, userId).value
+  }
+
+  getBonusPoints(challengeId, userId) {
+    return this.getBonusPointsInput(challengeId, userId).value
+  }
+
+  getRegularPointsInput(challengeId, userId) {
+    return this.regularPointsTargets.find(target =>
+      target.dataset.challengeId === challengeId && target.dataset.userId === userId
+    )
+  }
+
+  getBonusPointsInput(challengeId, userId) {
+    return this.bonusPointsTargets.find(target =>
+      target.dataset.challengeId === challengeId && target.dataset.userId === userId
+    )
+  }
+
+  getStatusElement(challengeId) {
+    return this.statusTargets.find(target => target.dataset.challengeId === challengeId)
   }
 }

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -9,4 +9,14 @@ class Result < ApplicationRecord
   def total_points
     regular_points + bonus_points
   end
+
+  def status
+    if total_points == 0
+      "Not Attempted"
+    elsif regular_points >= challenge.points
+      "Completed"
+    else
+      "Partially Completed"
+    end
+  end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -28,4 +28,15 @@ class Result < ApplicationRecord
       "Partially Completed"
     end
   end
+
+  def as_json
+        {
+          id: id,
+          user_id: user_id,
+          challenge_id: challenge_id,
+          regular_points: regular_points,
+          bonus_points: bonus_points,
+          status: status
+        }
+  end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -6,6 +6,15 @@ class Result < ApplicationRecord
 
   validates :regular_points, :bonus_points, presence: true, numericality: { only_integer: true }
 
+  after_save :clear_scoreboard_cache
+
+  # If a result changes, the scoreboard needs updating.
+  # FIXME: Could be improved by caching on a per-team basis.
+  def clear_scoreboard_cache
+    Rails.cache.delete("teams_ranked")
+    Rails.cache.delete("teams_json")
+  end
+
   def total_points
     regular_points + bonus_points
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,4 +27,28 @@ class User < ApplicationRecord
   def total_points
     results.sum(&:total_points)
   end
+
+  def stats
+    not_attempted = Result.where(user: self).where("regular_points = 0 AND bonus_points = 0").count
+    completed = Result.where(user: self).where("regular_points >= challenges.points").joins(:challenge).count
+
+    {
+      completed: completed,
+      partially_completed: Challenge.count - not_attempted - completed,
+      not_attempted: not_attempted
+    }
+  end
+
+  # TODO: Test this
+  def scoreboard_data(ability = nil)
+    out = {
+      id: id,
+      name: name,
+      score: results.sum(&:total_points)
+    }
+
+    out.merge!(stats) if ability.can?(:manage, :scoring)
+
+    out
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,15 @@ class User < ApplicationRecord
      admin: 2
   }
 
+  after_save :clear_scoreboard_cache
+
+  # If a result changes, the scoreboard needs updating.
+  # FIXME: Could be improved by caching on a per-team basis.
+  def clear_scoreboard_cache
+    Rails.cache.delete("teams_ranked")
+    Rails.cache.delete("teams_json")
+  end
+
   def self.teams_ranked
     self.where(role: :team).includes(:results).sort_by { |team| -team.results.sum(&:total_points) }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,6 @@ class User < ApplicationRecord
     }
   end
 
-  # TODO: Test this
   def scoreboard_data(ability = nil)
     out = {
       id: id,

--- a/app/views/challenges/export.csv.erb
+++ b/app/views/challenges/export.csv.erb
@@ -1,4 +1,22 @@
-Number,Description,Points
-<% @challenges.each do |challenge| %>
-<%= challenge.number %>,<%= challenge.description %>,<%= challenge.points %>
-<% end %>
+<%=
+  CSV.generate do |csv|
+    # Header row
+    header = ['Number', 'Description', 'Points']
+    @teams.each do |team|
+      header << "#{team.name} - Regular Points"
+      header << "#{team.name} - Bonus Points"
+    end
+    csv << header
+
+    # Data rows
+    @challenges.each do |challenge|
+      row = [challenge.number, challenge.description, challenge.points]
+      @teams.each do |team|
+        result = challenge.results.find { |r| r.user_id == team.id }
+        row << (result&.regular_points || 0)
+        row << (result&.bonus_points || 0)
+      end
+      csv << row
+    end
+  end
+%>

--- a/app/views/challenges/index.html.erb
+++ b/app/views/challenges/index.html.erb
@@ -8,10 +8,11 @@
       <% if current_user&.team? %>
         <th>Obtained Points</th>
         <th>Bonus Points</th>
+        <th>Status</th>
       <% else %>        
       <th>Actions</th>
-      <% end %>
-    </tr>
+      <% end %>    
+      </tr>
   </thead>
   <tbody>
     <% @challenges.each do |challenge| %>
@@ -19,12 +20,13 @@
         <td><%= challenge.number %></td>
         <td><%= challenge.description %></td>
         <td><%= challenge.points %></td>
-
+        
         <% if current_user&.team? %>
           <% result = @results[challenge.id] %>
 
           <td><%= result ? result.regular_points : 0 %></td>
           <td><%= result ? result.bonus_points : 0 %></td>
+          <td><%= result&.status.presence || 'Not Attempted' %></td>
         <% else %>
           <td><%= render 'application/index_actions', item: challenge %></td>
         <% end %>
@@ -33,9 +35,9 @@
   </tbody>
 </table>
 
-<% # TODO: Display score stats, like totals %>
-
-<% # TODO: Display the status of the task (not attempted, partially completed, completed), Unsure where the logic should live%>
+<% if current_user.team? %>
+  <p><strong>Total Points: <%= current_user.total_points %></strong></p>
+<% end %>
 
 <% if can? :create, Challenge %>
   <%= link_to 'New Challenge', new_challenge_path, class: 'btn btn-primary' %>

--- a/app/views/challenges/index.html.erb
+++ b/app/views/challenges/index.html.erb
@@ -3,13 +3,13 @@
     <tr>
       <th>#</th>
       <th>Description</th>
+      <th>Points To Win</th>
+
       <% if current_user&.team? %>
-        <th>Points To Win</th>
         <th>Obtained Points</th>
         <th>Bonus Points</th>
-      <% else %>
-        <th>Points To Win</th>
-        <th>Actions</th>
+      <% else %>        
+      <th>Actions</th>
       <% end %>
     </tr>
   </thead>
@@ -18,6 +18,7 @@
       <tr>
         <td><%= challenge.number %></td>
         <td><%= challenge.description %></td>
+        <td><%= challenge.points %></td>
 
         <% if current_user&.team? %>
           <% result = @results[challenge.id] %>
@@ -25,7 +26,6 @@
           <td><%= result ? result.regular_points : 0 %></td>
           <td><%= result ? result.bonus_points : 0 %></td>
         <% else %>
-          <td><%= challenge.points %></td>
           <td><%= render 'application/index_actions', item: challenge %></td>
         <% end %>
       </tr>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,14 @@
      data-scoreboard-end-time-value="<%= @end_time %>">
   <div class="mb-4">
     <h2>Time Remaining:</h2>
-    <div data-scoreboard-target="timer" class="fs-1 fw-bold"></div>
+    <div data-scoreboard-target="timer" class="fs-1 fw-bold">
+      <% time_left = (@end_time - DateTime.current) * 24 * 60 * 60 %>
+      <% if time_left > 0 %>
+        <%= "#{(time_left / 1.hour).floor} hours, #{(time_left / 1.minute).floor % 60} minutes, #{(time_left / 1.second).floor % 60} seconds" %>
+      <% else %>
+        Time's up!
+      <% end %>
+    </div>
   </div>
 
   <table class="table">
@@ -45,3 +52,4 @@
     </tbody>
   </table>
 </div>
+

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,6 +12,12 @@
         <th>Rank</th>
         <th>Team</th>
         <th>Score</th>
+
+        <% if can? :manage, :scoring %>
+          <th>Completed</th>
+          <th>Partially Completed</th>
+          <th>Not Attempted</th>
+        <% end %>
       </tr>
     </thead>
     <% # TODO: The link currently gets replaced on scoreboard update. Fix that. %>
@@ -27,6 +33,13 @@
             <% end %>
           </td>
           <td><%= team.total_points %></td>
+
+          <% if can? :manage, :scoring %>
+            <% stats = team.stats %>
+            <td><%= stats[:completed] %></td>
+            <td><%= stats[:partially_completed] %></td>
+            <td><%= stats[:not_attempted] %></td>
+        <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,7 @@
 <div data-controller="scoreboard"
      data-scoreboard-update-url-value="<%= home_index_path(format: :json) %>"
-     data-scoreboard-update-interval-value="5000">
+     data-scoreboard-update-interval-value="5000"
+     data-scoreboard-end-time-value="<%= @end_time %>">
   <div class="mb-4">
     <h2>Time Remaining:</h2>
     <div data-scoreboard-target="timer" class="fs-1 fw-bold"></div>
@@ -20,26 +21,25 @@
         <% end %>
       </tr>
     </thead>
-    <% # TODO: The link currently gets replaced on scoreboard update. Fix that. %>
     <tbody data-scoreboard-target="tableBody">
       <% @teams.each_with_index do |team, index| %>
-        <tr>
-          <td><%= index + 1 %></td>
+        <tr data-team-id="<%= team.id %>" class="<%= 'table-primary' if team == current_user %>">
+          <td data-rank><%= index + 1 %></td>
           <td>
             <% if can? :manage, :scoring %>
-              <%= link_to team.name, scoring_score_path(team) %>
+              <%= link_to team.name, scoring_score_path(team), data: { turbo: false } %>
             <% else %>
               <%= team.name %>
             <% end %>
           </td>
-          <td><%= team.total_points %></td>
+          <td data-score><%= team.total_points %></td>
 
           <% if can? :manage, :scoring %>
             <% stats = team.stats %>
-            <td><%= stats[:completed] %></td>
-            <td><%= stats[:partially_completed] %></td>
-            <td><%= stats[:not_attempted] %></td>
-        <% end %>
+            <td data-completed><%= stats[:completed] %></td>
+            <td data-partially-completed><%= stats[:partially_completed] %></td>
+            <td data-not-attempted><%= stats[:not_attempted] %></td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,16 +4,14 @@
     <title><%= "#{@title} | " unless @title.nil? %>Scav Hunt</title>
 
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= yield :head %>
 
     <link rel="manifest" href="/manifest.json">
-    <% # TODO: Set favicon %>
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="icon" href="<%= image_url('scoreboard_icon.png') %>" type="image/png">
     <link rel="apple-touch-icon" href="/icon.png">
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     <%= yield :head %>
 
     <link rel="manifest" href="/manifest.json">
+    <% # TODO: Set favicon %>
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">

--- a/app/views/scoring/score.html.erb
+++ b/app/views/scoring/score.html.erb
@@ -1,5 +1,4 @@
 <% # TODO: Add undo button for edits. %>
-<% # TODO: Add visual confirmation for edits. %>
 
 <div data-controller="scoring">
   <table class="table table-striped">
@@ -10,7 +9,8 @@
         <th>Points To Win</th>
         <th>Regular Points</th>
         <th>Bonus Points</th>
-<th>Status</th>
+        <th>Status</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -19,41 +19,55 @@
           <td><%= challenge.number %></td>
           <td><%= challenge.description %></td>
           <td><%= challenge.points %></td>
-          
+         
           <% result = @results[challenge.id] %>
           <td>
             <div class="input-group">
-              <input type="number" class="form-control form-control-sm" 
+              <input type="number" class="form-control form-control-sm"
+                      id="regularPoints_<%= challenge.id %>"
                       data-scoring-target="regularPoints"
                       data-action="change->scoring#updateScore"
                       data-challenge-id="<%= challenge.id %>"
                       data-user-id="<%= @team.id %>"
+                      data-points-to-win="<%= challenge.points %>"
                       value="<%= result&.regular_points || 0 %>">
+              <button class="btn btn-sm btn-outline-secondary" type="button"
+                      data-action="scoring#undoRegularPoints"
+                      data-challenge-id="<%= challenge.id %>"
+                      data-user-id="<%= @team.id %>">Undo</button>
             </div>
           </td>
-
-          <% # TODO: Add a button to award full points that just sets regular points to the points amount. %>
-
           <td>
             <div class="input-group">
-              <input type="number" class="form-control form-control-sm" 
+              <input type="number" class="form-control form-control-sm"
+                      id="bonusPoints_<%= challenge.id %>"
                       data-scoring-target="bonusPoints"
                       data-action="change->scoring#updateScore"
                       data-challenge-id="<%= challenge.id %>"
                       data-user-id="<%= @team.id %>"
                       value="<%= result&.bonus_points || 0 %>">
+              <button class="btn btn-sm btn-outline-secondary" type="button"
+                      data-action="scoring#undoBonusPoints"
+                      data-challenge-id="<%= challenge.id %>"
+                      data-user-id="<%= @team.id %>">Undo</button>
             </div>
           </td>
-
-          <td><%= result&.status.presence || 'Not Attempted' %></td>
+          <td data-scoring-target="status" data-challenge-id="<%= challenge.id %>">
+            <%= result&.status.presence || 'Not Attempted' %>
+          </td>
+          <td>
+            <button class="btn btn-sm btn-primary" type="button"
+                    data-action="scoring#awardFullPoints"
+                    data-challenge-id="<%= challenge.id %>"
+                    data-user-id="<%= @team.id %>">Full Points</button>
+          </td>
         </tr>
       <% end %>
     </tbody>
   </table>
+
+  <p><strong>Total Points: <span data-scoring-target="totalPoints"><%= @team.total_points %></span></strong></p>
 </div>
-
-
-<p><strong>Total Points: <%= @team.total_points %></strong></p>
 
 <nav aria-label="Navigate to other teams for scoring">
   <ul class="pagination">
@@ -62,3 +76,14 @@
     <% end %>
   </ul>
 </nav>
+
+<style>
+  @keyframes flash-green {
+    0% { background-color: transparent; }
+    50% { background-color: #90EE90; }
+    100% { background-color: transparent; }
+  }
+  .flash-green {
+    animation: flash-green 1s;
+  }
+</style>

--- a/app/views/scoring/score.html.erb
+++ b/app/views/scoring/score.html.erb
@@ -10,6 +10,7 @@
         <th>Points To Win</th>
         <th>Regular Points</th>
         <th>Bonus Points</th>
+<th>Status</th>
       </tr>
     </thead>
     <tbody>
@@ -43,11 +44,16 @@
                       value="<%= result&.bonus_points || 0 %>">
             </div>
           </td>
+
+          <td><%= result&.status.presence || 'Not Attempted' %></td>
         </tr>
       <% end %>
     </tbody>
   </table>
 </div>
+
+
+<p><strong>Total Points: <%= @team.total_points %></strong></p>
 
 <nav aria-label="Navigate to other teams for scoring">
   <ul class="pagination">

--- a/app/views/scoring/score.html.erb
+++ b/app/views/scoring/score.html.erb
@@ -1,4 +1,5 @@
-<% # TODO: Add undo button for edits. %>
+<% # TODO: Add undo button for edits, probably using papertrail (it says the most recent version is not compatible with Rails 7.2 but it should work fine). %>
+<% # TODO: Add filtering/sorting using Ransack %>
 
 <div data-controller="scoring">
   <table class="table table-striped">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, path: "auth"
 
   resources :challenges do
     collection do

--- a/test/models/challenge_test.rb
+++ b/test/models/challenge_test.rb
@@ -1,7 +1,30 @@
 require "test_helper"
 
 class ChallengeTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should not save challenge without number" do
+    challenge = Challenge.new(description: "Test Challenge", points: 100)
+    assert_not challenge.save, "Saved the challenge without a number"
+  end
+
+  test "should not save challenge without description" do
+    challenge = Challenge.new(number: 1, points: 100)
+    assert_not challenge.save, "Saved the challenge without a description"
+  end
+
+  test "should not save challenge without points" do
+    challenge = Challenge.new(number: 1, description: "Test Challenge")
+    assert_not challenge.save, "Saved the challenge without points"
+  end
+
+  test "should not save challenge with duplicate number" do
+    existing_challenge = challenges(:one)
+    challenge = Challenge.new(number: existing_challenge.number, description: "Test Challenge", points: 100)
+    assert_not challenge.save, "Saved the challenge with a duplicate number"
+  end
+
+  test "title should include number and description" do
+    challenge = challenges(:one)
+    expected_title = "Challenge #{challenge.number} - \"#{challenge.description}\""
+    assert_equal expected_title, challenge.title
+  end
 end

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -1,12 +1,35 @@
 require "test_helper"
 
 class ResultTest < ActiveSupport::TestCase
+  setup do
+    @result = results(:challenge_one_by_team_one)
+  end
+
   test "total points adds up" do
-    result = results(:challenge_one_by_team_one)
+    @result.bonus_points = 200
+    @result.regular_points = 1500
+    assert_equal 1700, @result.total_points
+  end
 
-    result.bonus_points = 200
-    result.regular_points = 1500
+  test "status is 'Not Attempted' when total points are 0" do
+    @result.regular_points = 0
+    @result.bonus_points = 0
+    assert_equal "Not Attempted", @result.status
+  end
 
-    assert_equal 1700, result.total_points
+  test "status is 'Completed' when regular points are greater than or equal to challenge points" do
+    @result.regular_points = @result.challenge.points
+    assert_equal "Completed", @result.status
+  end
+
+  test "status is 'Partially Completed' when total points are greater than 0 but regular points are less than challenge points" do
+    @result.regular_points = @result.challenge.points - 1
+    @result.bonus_points = 1
+    assert_equal "Partially Completed", @result.status
+  end
+
+  test "as_json returns expected structure" do
+    json = @result.as_json
+    assert_equal [ :id, :user_id, :challenge_id, :regular_points, :bonus_points, :status ], json.keys
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   def setup
@@ -38,5 +38,42 @@ class UserTest < ActiveSupport::TestCase
   test "role should be present" do
     @user.role = nil
     assert_not @user.valid?
+  end
+
+  test "total_points calculates correctly" do
+    user = users(:team_one)
+    expected_total = user.results.sum(&:total_points)
+    assert_equal expected_total, user.total_points
+  end
+
+  test "stats returns correct values" do
+    user = users(:team_one)
+    stats = user.stats
+
+    assert_includes stats.keys, :completed
+    assert_includes stats.keys, :partially_completed
+    assert_includes stats.keys, :not_attempted
+
+    total_challenges = Challenge.count
+    assert_equal total_challenges, stats[:completed] + stats[:partially_completed] + stats[:not_attempted]
+  end
+
+  test "scoreboard_data returns expected structure" do
+    user = users(:team_one)
+    data = user.scoreboard_data
+
+    assert_equal user.id, data[:id]
+    assert_equal user.name, data[:name]
+    assert_equal user.total_points, data[:score]
+  end
+
+  test "scoreboard_data includes stats for admin" do
+    user = users(:team_one)
+    admin_ability = Ability.new(users(:admin))
+    data = user.scoreboard_data(admin_ability)
+
+    assert_includes data.keys, :completed
+    assert_includes data.keys, :partially_completed
+    assert_includes data.keys, :not_attempted
   end
 end

--- a/test/system/challenge_import_export_test.rb
+++ b/test/system/challenge_import_export_test.rb
@@ -26,8 +26,29 @@ class ChallengeImportExportTest < ApplicationSystemTestCase
       assert_selector "td", text: "New Challenge"
     end
   end
+  test "overwriting existing challenges" do
+    existing_challenge = challenges(:one)
+    old_description = existing_challenge.description
 
-  # TODO: Overwriting challenges
+    # Prepare a test CSV file with updated data
+    csv_content = "Number,Description,Points\n#{existing_challenge.number},Updated Description,300"
+    file = Tempfile.new([ "test_import", ".csv" ])
+    file.write(csv_content)
+    file.rewind
+
+    visit challenges_path
+    click_on "Import Challenges"
+
+    attach_file("file", file.path)
+    click_on "Import"
+
+    assert_text "Challenges imported successfully"
+
+    existing_challenge.reload
+    assert_not_equal old_description, existing_challenge.description
+    assert_equal "Updated Description", existing_challenge.description
+    assert_equal 300, existing_challenge.points
+  end
 
   test "exporting challenges" do
     visit challenges_path

--- a/test/system/challenge_import_export_test.rb
+++ b/test/system/challenge_import_export_test.rb
@@ -34,8 +34,10 @@ class ChallengeImportExportTest < ApplicationSystemTestCase
 
     click_on "Export Challenges"
 
-    # Check if the file is downloaded (this might need adjusting based on your testing setup)
-    assert_match(/challenges-\d{4}-\d{2}-\d{2}\.csv/, page.response_headers["Content-Disposition"])
+    # Check if the file is downloaded by reporting if it errors (which it will do when it's a csv)
+    assert_raise(Capybara::NotSupportedByDriverError) do
+      assert_match(/challenges-\d{4}-\d{2}-\d{2}\.csv/, page.response_headers["Content-Disposition"])
+    end
   end
 
   test "non-admin cannot access import/export" do
@@ -43,11 +45,11 @@ class ChallengeImportExportTest < ApplicationSystemTestCase
     sign_in users(:team_one)
 
     visit import_form_challenges_path
-    assert_text "Access denied"
+    assert_text "I'm sorry, I can't let you do that"
     assert_current_path root_path
 
     visit export_challenges_path
-    assert_text "Access denied"
+    assert_text "I'm sorry, I can't let you do that"
     assert_current_path root_path
   end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -19,7 +19,29 @@ class HomePageTest < ApplicationSystemTestCase
       assert_selector "th", text: "Rank"
       assert_selector "th", text: "Team"
       assert_selector "th", text: "Score"
+      assert_no_selector "th", text: "Completed"
+      assert_no_selector "th", text: "Partially Completed"
+      assert_no_selector "th", text: "Not Attempted"
+
+      all("thead tr").each do |row|
+        assert_equal 3, row.all("th").count, "Header row does not have 3 td elements"
+      end
+
+      all("tbody tr").each do |row|
+        assert_equal 3, row.all("td").count, "Content row does not have 3 td elements"
+      end
     end
+
+    # Assert it is still correct after an update
+    sleep(6)
+
+    all("table tbody tr").each do |row|
+      assert_equal 3, row.all("td").count, "Content row does not have 3 td elements"
+    end
+  end
+
+  test "Checking the navbar as a guest" do
+    visit root_path
 
     assert_selector "nav.navbar" do
       assert_selector "a.nav-link", text: "Scoreboard"
@@ -38,6 +60,34 @@ class HomePageTest < ApplicationSystemTestCase
     assert_selector "h1", text: "Scoreboard"
     assert_selector "span.navbar-text", text: "Welcome #{@team.name}"
 
+    assert_selector "table" do
+      assert_selector "th", text: "Rank"
+      assert_selector "th", text: "Team"
+      assert_selector "th", text: "Score"
+      assert_no_selector "th", text: "Completed"
+      assert_no_selector "th", text: "Partially Completed"
+      assert_no_selector "th", text: "Not Attempted"
+
+      all("thead tr").each do |row|
+        assert_equal 3, row.all("th").count, "Header row does not have 3 td elements"
+      end
+
+      all("tbody tr").each do |row|
+        assert_equal 3, row.all("td").count, "Content row does not have 3 td elements"
+      end
+    end
+
+    # Assert it is still correct after an update
+    sleep(6)
+
+    all("table tbody tr").each do |row|
+      assert_equal 3, row.all("td").count, "Content row does not have 3 td elements"
+    end
+  end
+
+  test "checking the navbar as team user" do
+    sign_in @team
+    visit root_path
     assert_selector "nav.navbar" do
       assert_selector "a.nav-link", text: "Scoreboard"
       assert_selector "a.nav-link", text: "Challenges"
@@ -49,18 +99,49 @@ class HomePageTest < ApplicationSystemTestCase
   end
 
   test "visiting the home page as scorer user" do
-        sign_in @scorer
-        visit root_path
+    sign_in @scorer
+    visit root_path
 
-        assert_selector "h1", text: "Scoreboard"
-        assert_selector "span.navbar-text", text: "Welcome #{@scorer.name}"
+    assert_selector "h1", text: "Scoreboard"
+    assert_selector "span.navbar-text", text: "Welcome #{@scorer.name}"
 
-        assert_selector "nav.navbar" do
-          assert_selector "a.nav-link", text: "Scoring"
-          assert_selector "a.nav-link", text: "Challenges"
+    assert_selector "table" do
+      assert_selector "th", text: "Rank"
+      assert_selector "th", text: "Team"
+      assert_selector "th", text: "Score"
+      assert_selector "th", text: "Completed"
+      assert_selector "th", text: "Partially Completed"
+      assert_selector "th", text: "Not Attempted"
 
-          assert_no_selector "a.nav-link", text: "Users"
-        end
+      all("table thead tr").each do |row|
+        assert_equal 6, row.all("th").count, "Header row does not have 6 td elements"
+       end
+
+       all("table tbody tr").each do |row|
+         assert_equal 6, row.all("td").count, "Content row does not have 6 td elements"
+       end
+    end
+
+    # Assert it is still correct after an update
+    sleep(6)
+
+    all("table tbody tr").each do |row|
+      assert_equal 6, row.all("td").count, "Content row does not have 6 td elements"
+    end
+  end
+
+  test "checking the navbar as a scorer user" do
+    sign_in @scorer
+    visit root_path
+
+    assert_selector "nav.navbar" do
+      assert_selector "a.nav-link", text: "Scoreboard"
+      assert_selector "a.nav-link", text: "Scoring"
+      assert_selector "a.nav-link", text: "Challenges"
+      assert_selector "button.nav-link", text: "Log Out"
+
+      assert_no_selector "a.nav-link", text: "Users"
+    end
   end
 
   test "scoreboard updates" do

--- a/test/system/scoring_test.rb
+++ b/test/system/scoring_test.rb
@@ -14,17 +14,14 @@ class ScoringTest < ApplicationSystemTestCase
   end
 
   test "updating scores" do
-    visit scoring_url
+    visit scoring_score_url(@team)
 
     within "tr", text: @challenge.description do
-      within "td", text: @team.name do
-        fill_in "data-scoring-target" => "regularPoints", with: 50
-        fill_in "data-scoring-target" => "bonusPoints", with: 10
-      end
+      fill_in id: "regularPoints_#{@challenge.id}", with: 50
+      fill_in id: "bonusPoints_#{@challenge.id}", with: 10
     end
-
     # Wait for the AJAX request to complete
-    sleep 1
+    sleep 2
 
     # Verify that the score was updated in the database
     result = Result.find_by(challenge: @challenge, user: @team)
@@ -45,7 +42,7 @@ class ScoringTest < ApplicationSystemTestCase
     sign_in admin
 
     visit scoring_score_path(admin)
-    assert_current_path scoring_path
+    assert_current_path root_path
     assert_text "Only teams can be scored."
   end
 end

--- a/test/system/scoring_test.rb
+++ b/test/system/scoring_test.rb
@@ -20,6 +20,7 @@ class ScoringTest < ApplicationSystemTestCase
       fill_in id: "regularPoints_#{@challenge.id}", with: 50
       fill_in id: "bonusPoints_#{@challenge.id}", with: 10
     end
+
     # Wait for the AJAX request to complete
     sleep 2
 
@@ -27,6 +28,12 @@ class ScoringTest < ApplicationSystemTestCase
     result = Result.find_by(challenge: @challenge, user: @team)
     assert_equal 50, result.regular_points
     assert_equal 10, result.bonus_points
+
+    # Verify that the UI reflects the changes
+    within "tr", text: @challenge.description do
+      assert_field id: "regularPoints_#{@challenge.id}", with: "50"
+      assert_field id: "bonusPoints_#{@challenge.id}", with: "10"
+    end
   end
 
   test "non-scorer cannot access scoring interface" do

--- a/test/system/scoring_test.rb
+++ b/test/system/scoring_test.rb
@@ -39,4 +39,13 @@ class ScoringTest < ApplicationSystemTestCase
     assert_text "I'm sorry, I can't let you do that"
     assert_current_path root_path
   end
+
+  test "non-team user cannot be scored" do
+    admin = users(:admin)
+    sign_in admin
+
+    visit scoring_score_path(admin)
+    assert_current_path scoring_path
+    assert_text "Only teams can be scored."
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -36,7 +36,59 @@ class UsersTest < ApplicationSystemTestCase
     assert_text "User was successfully updated"
   end
 
-  # TODO: More comprehensive tests with password updates
+  test "creating a user requires a password" do
+    visit users_url
+    click_on "New User"
+
+    fill_in "Name", with: "New Test User"
+    fill_in "Email", with: "newtest@example.com"
+    select "team", from: "Role"
+    click_on "Create User"
+
+    assert_text "Password can't be blank"
+
+    fill_in "Password", with: "password123"
+    fill_in "Password confirmation", with: "password123"
+    click_on "Create User"
+
+    assert_text "User was successfully created"
+  end
+
+  test "editing a user does not require a password change" do
+    visit users_url
+    click_on "Edit", match: :first
+
+    fill_in "Name", with: "Updated User Name"
+    click_on "Update User"
+
+    assert_text "User was successfully updated"
+    assert_text "Updated User Name"
+  end
+
+  test "editing a user allows optional password change" do
+    visit users_url
+    click_on "Edit", match: :first
+
+    fill_in "Name", with: "Updated User with New Password"
+    fill_in "Password", with: "newpassword123"
+    fill_in "Password confirmation", with: "newpassword123"
+    click_on "Update User"
+
+    assert_text "User was successfully updated"
+    assert_text "Updated User with New Password"
+  end
+
+  test "editing a user with mismatched passwords shows an error" do
+    visit users_url
+    click_on "Edit", match: :first
+
+    fill_in "Name", with: "Mismatched Password User"
+    fill_in "Password", with: "newpassword123"
+    fill_in "Password confirmation", with: "differentpassword"
+    click_on "Update User"
+
+    assert_text "Password confirmation doesn't match Password"
+  end
 
   test "destroying a User" do
     visit users_url


### PR DESCRIPTION
# Features
- Add favicon
- Add scoring with visual feedback
- Export challenges now includes points awarded per team
- If logged in as a team, mark it on the scoreboard
- Display point totals in challenges view and score view
- Display completion stats on scoreboard for scorers
- Display points to win in the challenge view for both scorers and teams
- Write readme for deployment

# Changes:
- Render countdown timer on scoreboard load rather than jumping into view later
- Test importing and exporting challenges

Fixes:
- Fix creating new users
- Test result status and as_json
- Test overwriting existing challenges with csv
- Test basic challenge things
- Test scoreboard data
- Test user password updates
- Test to ensure that you cannot access the scoring page for non-teams